### PR TITLE
Removed extraneous H1 from post.html

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,8 @@ GEM
     mercenary (0.3.6)
     mini_portile2 (2.4.0)
     multipart-post (2.1.1)
+    nokogiri (1.10.8)
+      mini_portile2 (~> 2.4.0)
     nokogiri (1.10.8-x64-mingw32)
       mini_portile2 (~> 2.4.0)
     octokit (4.15.0)
@@ -78,7 +80,6 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.6.0)
-    wdm (0.1.1)
 
 PLATFORMS
   ruby
@@ -90,7 +91,6 @@ DEPENDENCIES
   jekyll-paginate
   jekyll-seo-tag
   jekyll-target-blank
-  wdm (>= 0.1.0)
 
 BUNDLED WITH
-   2.1.3
+   2.1.4

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,14 +3,14 @@ layout: default
 ---
 
 <article class="post">
-<h1 class="post-title">{% if page.link %}
+{% if page.link %}
 <h1 class="post-title"><a href="{{ page.link }}">
   {{ page.title | smartify }} <span class="link-arrow">&rarr;</span></a>
 </h1>
   {% else %}
 <h1 class="post-title">{{ page.title | smartify }}</h1>
-  {% endif %}</h1>
-  
+{% endif %
+
   <time datetime="{{ page.date | date_to_xmlschema }}" class="post-date">{{ page.date | date_to_long_string: "ordinal", "US" }}
   {% if post %}
   {% assign categories = post.categories %}
@@ -25,9 +25,9 @@ layout: default
   <br><i>Last updated on: {{ page.last_modified_at | date_to_long_string: "ordinal", "US" }}</i>
   {%- endif -%}
   </time>{% if page.link %}<span class="external-link">External Link</span>{% endif %}
-  
+
   {{ content | smartify }}
-  
+
   <br>
   <div class="tag-list">
   {% if post %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -9,7 +9,7 @@ layout: default
 </h1>
   {% else %}
 <h1 class="post-title">{{ page.title | smartify }}</h1>
-{% endif %
+{% endif %}
 
   <time datetime="{{ page.date | date_to_xmlschema }}" class="post-date">{{ page.date | date_to_long_string: "ordinal", "US" }}
   {% if post %}


### PR DESCRIPTION
There's an extraneous H1 wrapped around the {% if page.link %} statement that will throw a warning on an HTML validation check.