### PR TITLE
Improved display of post header when multiple categories

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -10,24 +10,24 @@ layout: default
   {% else %}
 <h1 class="post-title">{{ page.title | smartify }}</h1>
   {% endif %}
-  
+
   <time datetime="{{ page.date | date_to_xmlschema }}" class="post-date">{{ page.date | date_to_long_string: "ordinal", "US" }}
   {% if post %}
   {% assign categories = post.categories %}
   {% else %}
   {% assign categories = page.categories %}
   {% endif %}
+  {% if categories.size > 0 %}in{% endif %}
   {% for category in categories %}
-  in <a href="{{site.baseurl}}/categories/#{{category|slugize}}">{{category}}</a>
-  {% unless forloop.last %}&nbsp;{% endunless %}
+  <a href="{{site.baseurl}}/categories/#{{category|slugize}}">{{category}}</a>{% unless forloop.last %},{% endunless %}
   {% endfor %}
   {%- if page.last_modified_at -%}
   <br><i>Last updated on: {{ page.last_modified_at | date_to_long_string: "ordinal", "US" }}</i>
   {%- endif -%}
   </time>{% if page.link %}<span class="external-link">External Link</span>{% endif %}
-  
+
   {{ content | smartify }}
-  
+
   <br>
   <div class="tag-list">
   {% if post %}

--- a/index.html
+++ b/index.html
@@ -15,9 +15,9 @@ title: Home
     {% else %}
     {% assign categories = page.categories %}
     {% endif %}
+    {% if categories.size > 0 %}in{% endif %}
     {% for category in categories %}
-    in <a href="{{site.baseurl}}/categories/#{{category|slugize}}">{{category}}</a>
-    {% unless forloop.last %}&nbsp;{% endunless %}
+    <a href="{{site.baseurl}}/categories/#{{category|slugize}}">{{category}}</a>{% unless forloop.last %},{% endunless %}
     {% endfor %}
     {%- if post.last_modified_at -%}
     <br><i>Last updated on: {{ post.last_modified_at | date_to_long_string: "ordinal", "US" }}</i>
@@ -31,7 +31,7 @@ title: Home
 </span>
 
     {{ post.content | smartify }}
-	
+
   <br>
   <div class="tag-list">
   {% if post %}
@@ -44,7 +44,7 @@ title: Home
   {% unless forloop.last %}&nbsp;{% endunless %}
   {% endfor %}
   </div>
-	
+
   </article>
   {% endfor %}
 </div>


### PR DESCRIPTION
When a post has multiple categories, we no longer show:

    in Category1  in Category2

(note: there was an extra space between "Category1" and "in", due to the hard space)

We now show:

    in Category1, Category2

Before:
![before](https://user-images.githubusercontent.com/327741/81590786-61de9080-9389-11ea-8f6c-76037aa821fb.png)

After:
![after](https://user-images.githubusercontent.com/327741/81590794-673bdb00-9389-11ea-83fe-78130f02fd83.png)
